### PR TITLE
Fixes issue #96

### DIFF
--- a/src/sparselm/model_selection.py
+++ b/src/sparselm/model_selection.py
@@ -215,10 +215,9 @@ class GridSearchCV(_GridSearchCV):
                         params.append(p)
             params_sum = np.sum(params, axis=0)
             one_std_dists = np.abs(metrics - m + sig)
-            candidates = np.arange(len(metrics))[
-                one_std_dists < (np.min(one_std_dists) + 0.1 * sig)
-            ]
-            best_index = candidates[np.argmax(params_sum[candidates])]
+            # Guarantees that one-std rule always select larger params than max score.
+            candidates = np.arange(len(metrics))[params_sum >= params_sum[opt_index]]
+            best_index = candidates[np.argmin(one_std_dists[candidates])]
             return best_index
 
     # Overwrite original fit method to allow multiple optimal methods.


### PR DESCRIPTION
… rule always yields larger parameters than the optimal CV rule.

<!---Edit the following according to your PR.-->

## Summary

<!---Include a summary of major changes in bullet points:
* Feature 1
* Feature 2
* Fix 1
* Fix 2
-->
* Fixes #96 
* Added a test to guarantee that the one-std rule always yields larger parameters and sparser model than the optimal CV rule. 
* Current behavior of the one-std rule selector: 
![image](https://github.com/CederGroupHub/sparse-lm/assets/28149881/b6a0702e-57cb-4fa3-84c5-eafb859a355f)


## Additional dependencies introduced (if any)

<!---* List all new dependencies needed and justify why. Provide a justification why
that dependency is needed.-->
N/A

## TODO (if any)

<!---Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title, and write something about what else needs
to be done
* Feature 1 supports A, but not B.-->


## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
      Run [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) and [flake8](http://flake8.pycqa.org/en/latest/)
      on your local machine.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
      Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All existing tests pass.

<!---The CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.-->
